### PR TITLE
Correction of Input Parameter

### DIFF
--- a/docs/t-sql/functions/datepart-transact-sql.md
+++ b/docs/t-sql/functions/datepart-transact-sql.md
@@ -68,7 +68,7 @@ DATEPART ( datepart , date )
 |**DAYOFYEAR**|**dy**, **y**|  
 |**dia**|**dd**, **d**|  
 |**semana**|**wk**, **ww**|  
-|**dia da semana**|**data warehouse**|  
+|**dia da semana**|**dw**|  
 |**hora**|**hh**|  
 |**minuto**|**min, n**|  
 |**segundo**|**SS**, **s**|  


### PR DESCRIPTION
Translation correction:
In the Input Arguments section, changed from "data warehouse" to "dw"