### PR TITLE
Erro de tradução no momento da migração.

### DIFF
--- a/docs/dma/dma-bestpractices.md
+++ b/docs/dma/dma-bestpractices.md
@@ -32,7 +32,7 @@ Não instale e execute o Assistente de migração de dados diretamente no comput
 - Executar o **problemas de compatibilidade** e **nova recomendação de recurso** avaliações separadamente para reduzir a duração de avaliação.
 
 ## <a name="migration"></a>Migração
-- Não migre um servidor durante horários de pico.
+- Migre um servidor fora dos horários de pico.
 
 - Ao migrar um banco de dados, forneça um local único compartilhamento acessível pelo servidor de origem e o servidor de destino e evite uma operação de cópia, se possível. Uma operação de cópia pode introduzir um atraso de acordo com o tamanho do arquivo de backup. A operação de cópia também aumenta as chances de que a migração falhará devido a uma etapa extra. Quando um único local é fornecido, o Assistente de migração de dados ignora a operação de cópia.
  

--- a/docs/dma/dma-bestpractices.md
+++ b/docs/dma/dma-bestpractices.md
@@ -32,7 +32,7 @@ Não instale e execute o Assistente de migração de dados diretamente no comput
 - Executar o **problemas de compatibilidade** e **nova recomendação de recurso** avaliações separadamente para reduzir a duração de avaliação.
 
 ## <a name="migration"></a>Migração
-- Migre um servidor durante horários de pico.
+- Não migre um servidor durante horários de pico.
 
 - Ao migrar um banco de dados, forneça um local único compartilhamento acessível pelo servidor de origem e o servidor de destino e evite uma operação de cópia, se possível. Uma operação de cópia pode introduzir um atraso de acordo com o tamanho do arquivo de backup. A operação de cópia também aumenta as chances de que a migração falhará devido a uma etapa extra. Quando um único local é fornecido, o Assistente de migração de dados ignora a operação de cópia.
  


### PR DESCRIPTION
Texto original está com "non-peak" e a tradução ficou como "horários de pico"